### PR TITLE
added trailing slash for bower register

### DIFF
--- a/registry/urls.py
+++ b/registry/urls.py
@@ -3,7 +3,7 @@ from api.views import PackagesListView, PackagesFindView, PackagesSearchView
 
 
 urlpatterns = patterns('',
-    url(r'^packages/$', PackagesListView.as_view(), name='list'),
-    url(r'^packages/(?P<name>[-\w]+)/$', PackagesFindView.as_view(), name='find'),
-    url(r'^packages/search/(?P<name>[-\w]+)/$', PackagesSearchView.as_view(), name='search')
+    url(r'^packages/?$', PackagesListView.as_view(), name='list'),
+    url(r'^packages/(?P<name>[-\w]+)/?$', PackagesFindView.as_view(), name='find'),
+    url(r'^packages/search/(?P<name>[-\w]+)/?$', PackagesSearchView.as_view(), name='search')
 )


### PR DESCRIPTION
bower register pkg_name pkg_address  works now, with ssh even. We modified the URLs file for trailing slashes so that it works with the default bower register client. 
