### PR TITLE
Allow dots in package names.

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -48,6 +48,14 @@ class PackagesFindViewTests(TestCase):
         self.assertEqual(result['url'], '/foo')
         self.assertEqual(result['name'], 'ember-data')
 
+    def test_returns_package_when_name_includes_period(self):
+        Package.objects.create(name="backbone.wreqr", url="/foo")
+        url = reverse("find", kwargs={'name': 'backbone.wreqr'})
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        result = json.loads(response.content)
+        self.assertEqual(result['name'], 'backbone.wreqr')
+
 
 class PackagesSearchViewTests(TestCase):
 
@@ -77,6 +85,16 @@ class PackagesSearchViewTests(TestCase):
         self.assertEqual(1, len(results))
         self.assertEqual(results[0]['url'], '/foo')
         self.assertEqual(results[0]['name'], 'ember-data')
+
+    def test_returns_list_of_packages_when_name_includes_period(self):
+        Package.objects.create(name="backbone.wreqr", url="/foo")
+        url = reverse("search", kwargs={'name': 'backbone.wre'})
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        results = json.loads(response.content)
+        self.assertEqual(1, len(results))
+        self.assertEqual(results[0]['url'], '/foo')
+        self.assertEqual(results[0]['name'], 'backbone.wreqr')
 
 
 class TestORM(object):

--- a/registry/urls.py
+++ b/registry/urls.py
@@ -4,6 +4,6 @@ from api.views import PackagesListView, PackagesFindView, PackagesSearchView
 
 urlpatterns = patterns('',
     url(r'^packages/?$', PackagesListView.as_view(), name='list'),
-    url(r'^packages/(?P<name>[-\w]+)/?$', PackagesFindView.as_view(), name='find'),
+    url(r'^packages/(?P<name>[-\w\.]+)/?$', PackagesFindView.as_view(), name='find'),
     url(r'^packages/search/(?P<name>[-\w\.]+)/?$', PackagesSearchView.as_view(), name='search')
 )

--- a/registry/urls.py
+++ b/registry/urls.py
@@ -5,5 +5,5 @@ from api.views import PackagesListView, PackagesFindView, PackagesSearchView
 urlpatterns = patterns('',
     url(r'^packages/?$', PackagesListView.as_view(), name='list'),
     url(r'^packages/(?P<name>[-\w]+)/?$', PackagesFindView.as_view(), name='find'),
-    url(r'^packages/search/(?P<name>[-\w]+)/?$', PackagesSearchView.as_view(), name='search')
+    url(r'^packages/search/(?P<name>[-\w\.]+)/?$', PackagesSearchView.as_view(), name='search')
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django<1.7
 south
-djangorestframework
+djangorestframework<2.5


### PR DESCRIPTION
Packages such as `backbone.wreqr` and `backbone.babysitter` where 404ing fixes #9 
